### PR TITLE
fix(Plugin): use @vitalets/google-translate-api for Google Translate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: node_js
 
 node_js:
-  - "4"
-  - "5"
+  - "6"
+  - "7"

--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ you can easily apply the apiname and apikey from [youdao](http://fanyi.youdao.co
 |:-------:|:-----:|:---------:|
 |`from`|`'zh-cn'`|string, what languages you want to translate from|
 |`to`|`'en'`|string, what languages you want to translate to|
+|`tld`|`'cn'`|string, which TLD of Google Translate you want to use, form: `translate.google.${tld}`|
 
 use [google-translate-api](https://github.com/matheuss/google-translate-api)
 

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
     "doc": "atool-doc"
   },
   "dependencies": {
+    "@vitalets/google-translate-api": "^2.8.0",
     "babel-polyfill": "^6.9.1",
     "co": "~4.6.0",
     "co-request": "~1.0.0",
     "commander": "~2.9.0",
     "ensure-dir": "^0.1.0",
     "glob": "~7.0.3",
-    "google-translate-api": "~2.3.0",
     "inquirer": "~1.0.3",
     "is-ali-env": "^0.1.2",
     "loader-utils": "~0.2.15",

--- a/src/plugins/google.js
+++ b/src/plugins/google.js
@@ -1,5 +1,5 @@
 import log from 'spm-log';
-import translate from 'google-translate-api';
+import translate from '@vitalets/google-translate-api';
 
 // https://github.com/matheuss/google-translate-response-spec
 
@@ -10,7 +10,7 @@ async function words(q, params) {
 }
 
 export default async function google(query) {
-  const { from = 'zh-cn', to = 'en' } = query;
+  const { from = 'zh-cn', to = 'en', tld = 'cn' } = query;
 
   const todo = this.getTodo();
   if (!(todo.length)) {
@@ -26,7 +26,7 @@ export default async function google(query) {
       log.warn('google', `skip ${id} from zh to en`);
     } else {
       for (const q of texts) {
-        const result = await words(q, { from, to });
+        const result = await words(q, { from, to, tld });
         log.info('google: zh -> en', `${q} -> ${result}`);
 
         this.setOption(id, 'en', {


### PR DESCRIPTION
Current google plugin of atool-I10n doesn't works, it's dependency `google-translate-api` is outdated, this PR does these two things:

1. Replace `google-translate-api` package with `@vitalets/google-translate-api` package
2. Add `tld` option for google translate plugin